### PR TITLE
Implement resubmit functionality

### DIFF
--- a/src/certificateActions.jsx
+++ b/src/certificateActions.jsx
@@ -30,6 +30,7 @@ import {
     KebabToggle
 } from "@patternfly/react-core";
 
+import { ResubmitCertificateModal } from './requestCertificate.jsx';
 import { removeRequest } from "./dbus.js";
 
 const _ = cockpit.gettext;
@@ -160,15 +161,26 @@ export class CertificateActions extends React.Component {
         this.state = {
             dropdownOpen: false,
             showRemoveModal: false,
+            showResubmitModal: false,
         };
 
         this.onValueChanged = this.onValueChanged.bind(this);
         this.onRemoveModalOpen = this.onRemoveModalOpen.bind(this);
         this.onRemoveModalClose = this.onRemoveModalClose.bind(this);
+        this.onResubmitModalOpen = this.onResubmitModalOpen.bind(this);
+        this.onResubmitModalClose = this.onResubmitModalClose.bind(this);
     }
 
     onValueChanged(key, value) {
         this.setState({ [key]: value });
+    }
+
+    onResubmitModalOpen() {
+        this.setState({ showResubmitModal: true });
+    }
+
+    onResubmitModalClose() {
+        this.setState({ showResubmitModal: false });
     }
 
     onRemoveModalOpen() {
@@ -180,10 +192,16 @@ export class CertificateActions extends React.Component {
     }
 
     render() {
-        const { idPrefix } = this.props;
-        const { dropdownOpen, showRemoveModal } = this.state;
+        const { idPrefix, cas, addAlert, cert, certPath } = this.props;
+        const { dropdownOpen, showRemoveModal, showResubmitModal } = this.state;
 
         const dropdownItems = [
+            <DropdownItem
+                key={`${idPrefix}-resubmit`}
+                id={`${idPrefix}-resubmit`}
+                onClick={this.onResubmitModalOpen}>
+                {_("Resubmit")}
+            </DropdownItem>,
             <DropdownItem className="pf-m-danger"
                 key={`${idPrefix}-remove`}
                 id={`${idPrefix}-remove`}
@@ -205,7 +223,16 @@ export class CertificateActions extends React.Component {
                     dropdownItems={dropdownItems}
                     isPlain />
 
-                {showRemoveModal && <RemoveModal onClose={this.onRemoveModalClose} {...this.props} />}
+                {showRemoveModal &&
+                    <RemoveModal onClose={this.onRemoveModalClose}
+                        {...this.props} />}
+                {showResubmitModal &&
+                    <ResubmitCertificateModal onClose={this.onResubmitModalClose}
+                        cas={cas}
+                        addAlert={addAlert}
+                        cert={cert}
+                        certPath={certPath}
+                        mode="resubmit" />}
             </>
         );
     }

--- a/src/certificateList.jsx
+++ b/src/certificateList.jsx
@@ -25,6 +25,8 @@ import {
     Badge,
     Flex,
     FlexModifiers,
+    Text,
+    TextVariants,
     Tooltip,
     TooltipPosition
 } from "@patternfly/react-core";
@@ -123,60 +125,97 @@ function getCAName(cas, cert) {
 }
 
 const generalDetails = ({ idPrefix, cas, cert, certPath, onAutorenewChanged }) => (
-    <Flex breakpointMods={[{ modifier: FlexModifiers["justify-content-space-between"] }]}>
-        <Flex breakpointMods={[{ modifier: FlexModifiers.column }, { modifier: FlexModifiers["flex-1"] }]}>
-            <div className="ct-form">
-                {cert.status && cert.status.v && <>
-                    <label className='control-label label-title' htmlFor={`${idPrefix}-general-status`}>{_("Status")}</label>
-                    <div id={`${idPrefix}-general-status`} role="group">
-                        {cert.stuck.v && (<span>
-                            <span className="fa fa-exclamation-triangle" />
-                            <span id={`${idPrefix}-general-stuck`}>{_("Stuck: ")}</span>
-                        </span>)}
-                        <span>
-                            {cert.status.v.includes('_')
-                                ? cert.status.v
-                                : cert.status.v.charAt(0) + cert.status.v.slice(1).toLowerCase()}
-                            <Tooltip position={TooltipPosition.top}
-                                entryDelay={0}
-                                content={certificateStates[cert.status.v]}>
-                                <span className="info-circle">
-                                    <InfoAltIcon />
-                                </span>
-                            </Tooltip>
+    <Flex breakpointMods={[{ modifier: FlexModifiers.column }]}>
+        <Flex breakpointMods={[{ modifier: FlexModifiers["justify-content-space-between"] }]}>
+            <Flex breakpointMods={[{ modifier: FlexModifiers.column }, { modifier: FlexModifiers["flex-1"] }]}>
+                <div className="ct-form">
+                    {cert.status && cert.status.v && <>
+                        <label className='control-label label-title' htmlFor={`${idPrefix}-general-status`}>{_("Status")}</label>
+                        <div id={`${idPrefix}-general-status`} role="group">
+                            {cert.stuck.v && (<span>
+                                <span className="fa fa-exclamation-triangle" />
+                                <span id={`${idPrefix}-general-stuck`}>{_("Stuck: ")}</span>
+                            </span>)}
+                            <span>
+                                {cert.status.v.includes('_')
+                                    ? cert.status.v
+                                    : cert.status.v.charAt(0) + cert.status.v.slice(1).toLowerCase()}
+                                <Tooltip position={TooltipPosition.top}
+                                    entryDelay={0}
+                                    content={certificateStates[cert.status.v]}>
+                                    <span className="info-circle">
+                                        <InfoAltIcon />
+                                    </span>
+                                </Tooltip>
+                            </span>
+                        </div>
+                    </>}
+                    {cert.ca && cert.ca.v && <>
+                        <label className='control-label label-title' htmlFor={`${idPrefix}-general-ca`}>{_("CA")}</label>
+                        <span id={`${idPrefix}-general-ca`}>{getCAName(cas, cert)}</span>
+                    </>}
+                </div>
+            </Flex>
+            <Flex breakpointMods={[{ modifier: FlexModifiers.column }, { modifier: FlexModifiers["flex-1"] }]}>
+                <div className="ct-form">
+                    {cert["not-valid-after"] && cert["not-valid-after"].v !== 0 && <>
+                        <label className='control-label label-title' htmlFor={`${idPrefix}-general-validity`}>
+                            {_("Valid")}
+                        </label>
+                        <span id={`${idPrefix}-general-validity`}>
+                            {prettyTime(cert["not-valid-before"].v) +
+                            _(" to ") + prettyTime(cert["not-valid-after"].v)}
                         </span>
-                    </div>
-                </>}
-                {cert.ca && cert.ca.v && <>
-                    <label className='control-label label-title' htmlFor={`${idPrefix}-general-ca`}>{_("CA")}</label>
-                    <span id={`${idPrefix}-general-ca`}>{getCAName(cas, cert)}</span>
-                </>}
-            </div>
+                    </>}
+                    {cert.autorenew && <>
+                        <label className='control-label label-title' htmlFor={`${idPrefix}-general-autorenewal`}>
+                            {_("Auto-renewal")}
+                        </label>
+                        <label className='checkbox-inline'>
+                            <input id={`${idPrefix}-general-autorenewal`}
+                                   type="checkbox"
+                                   checked={cert.autorenew.v}
+                                   onChange={() => onAutorenewChanged(cert, certPath)} />
+                            {_("Renew before expiration")}
+                        </label>
+                    </>}
+                </div>
+            </Flex>
         </Flex>
-        <Flex breakpointMods={[{ modifier: FlexModifiers.column }, { modifier: FlexModifiers["flex-1"] }]}>
-            <div className="ct-form">
-                {cert["not-valid-after"] && cert["not-valid-after"].v !== 0 && <>
-                    <label className='control-label label-title' htmlFor={`${idPrefix}-general-validity`}>
-                        {_("Valid")}
-                    </label>
-                    <span id={`${idPrefix}-general-validity`}>
-                        {prettyTime(cert["not-valid-before"].v) +
-                        _(" to ") + prettyTime(cert["not-valid-after"].v)}
-                    </span>
-                </>}
-                {cert.autorenew && <>
-                    <label className='control-label label-title' htmlFor={`${idPrefix}-general-autorenewal`}>
-                        {_("Auto-renewal")}
-                    </label>
-                    <label className='checkbox-inline'>
-                        <input id={`${idPrefix}-general-autorenewal`}
-                               type="checkbox"
-                               checked={cert.autorenew.v}
-                               onChange={() => onAutorenewChanged(cert, certPath)} />
-                        {_("Renew before expiration")}
-                    </label>
-                </>}
-            </div>
+
+        <Text component={TextVariants.h5}>
+            {_("Signing request properties")}
+        </Text>
+
+        <Flex breakpointMods={[{ modifier: FlexModifiers["justify-content-space-between"] }]}>
+            <Flex breakpointMods={[{ modifier: FlexModifiers.column }, { modifier: FlexModifiers["flex-1"] }]}>
+                <div className='ct-form'>
+                    {cert.subject && cert.subject.v && <>
+                        <label className='control-label label-title' htmlFor={`${idPrefix}-general-subject`}>
+                            {_("Subject name")}
+                        </label>
+                        <span id={`${idPrefix}-general-subject`}>{cert.subject.v}</span>
+                    </>}
+
+                    {cert.principal && cert.principal.v.length > 0 && <>
+                        <label className='control-label label-title' htmlFor={`${idPrefix}-general-principal`}>
+                            {_("Principal name")}
+                        </label>
+                        <span id={`${idPrefix}-general-principal`}>{cert.principal.v.join(", ")}</span>
+                    </>}
+                </div>
+            </Flex>
+
+            <Flex breakpointMods={[{ modifier: FlexModifiers.column }, { modifier: FlexModifiers["flex-1"] }]}>
+                <div className='ct-form'>
+                    {cert.hostname && cert.hostname.v.length > 0 && <>
+                        <label className='control-label label-title' htmlFor={`${idPrefix}-general-dns`}>
+                            {_("DNS name")}
+                        </label>
+                        <span id={`${idPrefix}-general-dns`}>{cert.hostname.v.join(", ")}</span>
+                    </>}
+                </div>
+            </Flex>
         </Flex>
     </Flex>
 );

--- a/src/certificateList.jsx
+++ b/src/certificateList.jsx
@@ -384,9 +384,10 @@ class CertificateList extends React.Component {
             };
         });
 
-        const actions = (
-            <RequestCertificate cas={cas} addAlert={addAlert} />
-        );
+        const actions = (<>
+            <RequestCertificate cas={cas} addAlert={addAlert} mode="import" />
+            <RequestCertificate cas={cas} addAlert={addAlert} mode="request" />
+        </>);
 
         return (
             <ListingTable caption={_("Certificates")}

--- a/src/certificateList.jsx
+++ b/src/certificateList.jsx
@@ -40,6 +40,7 @@ import { ListingPanel } from "../lib/cockpit-components-listing-panel.jsx";
 import { ListingTable } from "../lib/cockpit-components-table.jsx";
 import { modifyRequest } from "./dbus.js";
 import { certificateStates } from "./states.js";
+import { getCAName } from "./helpers.js";
 
 const _ = cockpit.gettext;
 function prettyTime(unixTime) {
@@ -117,11 +118,6 @@ function getExpirationTime(cert) {
         }
         return _("Expires on ") + prettyTime(cert["not-valid-after"].v);
     }
-}
-
-function getCAName(cas, cert) {
-    if (cert.ca && cas[cert.ca.v.replace("request", "ca")])
-        return cas[cert.ca.v.replace("request", "ca")].nickname.v;
 }
 
 const generalDetails = ({ idPrefix, cas, cert, certPath, onAutorenewChanged }) => (
@@ -370,6 +366,7 @@ class CertificateList extends React.Component {
                     { title: cert.ca && cert.ca.v && caTitle },
                     {
                         title: <CertificateActions certs={certs}
+                                 cas={cas}
                                  cert={cert}
                                  certPath={certPath}
                                  addAlert={addAlert}

--- a/src/dbus.js
+++ b/src/dbus.js
@@ -60,3 +60,8 @@ export function removeRequest(requestPath, updates) {
     return dbusCall("/org/fedorahosted/certmonger", "org.fedorahosted.certmonger",
                     "remove_request", [requestPath]);
 }
+
+export function resubmitRequest(requestPath) {
+    return dbusCall(requestPath, "org.fedorahosted.certmonger.request",
+                    "resubmit", []);
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,23 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export function getCAName(cas, cert) {
+    if (cert.ca && cas[cert.ca.v.replace("request", "ca")])
+        return cas[cert.ca.v.replace("request", "ca")].nickname.v;
+}

--- a/src/requestCertificate.jsx
+++ b/src/requestCertificate.jsx
@@ -23,7 +23,10 @@ import moment from "moment";
 import { Modal } from "patternfly-react";
 import {
     Button,
+    FormGroup,
+    Form,
     Radio,
+    TextArea,
     TextInput
 } from "@patternfly/react-core";
 
@@ -79,6 +82,69 @@ const CAsRow = ({ onValueChanged, dialogValues, cas }) => {
                     );
                 })}
             </Select.Select>
+        </>
+    );
+};
+
+const SetSigningParametersRow = ({ onValueChanged, dialogValues }) => {
+    return (
+        <label className='checkbox-inline'>
+            <input id='set-signing-parameters'
+                type='checkbox'
+                checked={dialogValues.signingParameters}
+                onChange={e => onValueChanged("signingParameters", !dialogValues.signingParameters)} />
+            {_("Set optional signing request parameters")}
+        </label>
+    );
+};
+
+const SubjectNameRow = ({ onValueChanged, dialogValues }) => {
+    return (
+        <>
+            <label className="control-label" htmlFor="subject-name">
+                {_("Subject name")}
+            </label>
+            <TextInput value={dialogValues.subjectName}
+                id="subject-name"
+                type="text"
+                onChange={(value) => onValueChanged("subjectName", value)}
+                aria-label={_("SubjectName input text")} />
+        </>
+    );
+};
+
+const DNSNameRow = ({ onValueChanged, dialogValues }) => {
+    return (
+        <>
+            <label className="control-label" htmlFor="dns-name">
+                {_("DNS names")}
+            </label>
+            <Form>
+                <FormGroup validated="default"
+                    className="dns-helper-text"
+                    helperText={_("Comma separated list of DNS names. Example: example.com,sub.example.com")}>
+                    <TextArea value={dialogValues.dnsName}
+                        id="dns-name"
+                        onChange={(value) => onValueChanged("dnsName", value)}
+                        resizeOrientation='vertical'
+                        aria-label={_("DNSName input text")} />
+                </FormGroup>
+            </Form>
+        </>
+    );
+};
+
+const PrincipalNameRow = ({ onValueChanged, dialogValues }) => {
+    return (
+        <>
+            <label className="control-label" htmlFor="principal-name">
+                {_("Principal name")}
+            </label>
+            <TextInput value={dialogValues.principalName}
+                id="principal-name"
+                type="text"
+                onChange={(value) => onValueChanged("principalName", value)}
+                aria-label={_("PrincipalName input text")} />
         </>
     );
 };
@@ -139,6 +205,9 @@ export class RequestCertificateModal extends React.Component {
             nickname: "",
             certFile: "",
             keyFile: "",
+            subjectName: "",
+            dnsName: "",
+            principalName: "",
         };
 
         this.onValueChanged = this.onValueChanged.bind(this);
@@ -158,12 +227,19 @@ export class RequestCertificateModal extends React.Component {
 
         if (key === "hostname" && !_userChangedNickname) {
             stateDelta.nickname = value + '_' + ca + '_' + moment().format("DD-MM-YYYYTHH:mm:ss");
+            stateDelta.subjectName = "CN=" + value;
         }
         if (key === "ca" && !_userChangedNickname) {
             stateDelta.nickname = hostname + '_' + value + '_' + moment().format("DD-MM-YYYYTHH:mm:ss");
         }
         if (key === "nickname")
             stateDelta._userChangedNickname = true;
+        if (key === "dnsName") {
+            value = value.replace(/\s/g, ',');
+            while (value.includes(",,"))
+                value = value.replace(",,", ',');
+            stateDelta.dnsName = value;
+        }
 
         this.setState(stateDelta);
     }
@@ -200,7 +276,20 @@ export class RequestCertificateModal extends React.Component {
             parameter["key-file"] = cockpit.variant("s", this.state.keyFile);
         }
 
-        console.log(parameter);
+        if (this.state.signingParameters) {
+            let subjectName = this.state.subjectName;
+            if (subjectName && !subjectName.includes("="))
+                subjectName = "CN=" + subjectName;
+            let dnsNames = this.state.dnsName.split(',');
+            dnsNames = dnsNames.filter(Boolean); // Removes empty string entries
+
+            if (subjectName)
+                parameter["template-subject"] = cockpit.variant("s", subjectName);
+            if (this.state.principalName)
+                parameter["template-principal"] = cockpit.variant("as", [this.state.principalName]);
+            if (this.state.dnsName)
+                parameter["template-hostname"] = cockpit.variant("as", dnsNames);
+        }
 
         addRequest(parameter)
                 .then(() => this.props.onClose())
@@ -227,7 +316,15 @@ export class RequestCertificateModal extends React.Component {
                     <CertFileRow dialogValues={this.state} onValueChanged={this.onValueChanged} />
                     <hr />
                     <KeyFileRow dialogValues={this.state} onValueChanged={this.onValueChanged} />
+                    <hr />
                 </>}
+
+                <SetSigningParametersRow dialogValues={this.state} onValueChanged={this.onValueChanged} />
+                {this.state.signingParameters && <div className="ct-form">
+                    <SubjectNameRow dialogValues={this.state} onValueChanged={this.onValueChanged} />
+                    <DNSNameRow dialogValues={this.state} onValueChanged={this.onValueChanged} />
+                    <PrincipalNameRow dialogValues={this.state} onValueChanged={this.onValueChanged} />
+                </div>}
 
                 <hr />
             </form>

--- a/src/requestCertificate.scss
+++ b/src/requestCertificate.scss
@@ -5,3 +5,8 @@
 .storage-row > * {
   margin-right: 1.5rem;
 }
+
+.dns-helper-text {
+  line-height: 1.5rem;
+  padding-top: 0rem;
+}

--- a/test/check-application
+++ b/test/check-application
@@ -319,8 +319,8 @@ class TestApplication(testlib.MachineCase):
 
         class RequestCertDialog(object):
             def __init__(
-                self, test_obj, ca=None, storage_type="NSSDB", nickname=None,
-                key_path="", cert_path=""
+                self, test_obj, ca="SelfSign", storage_type="NSSDB", nickname=None,
+                key_path="", cert_path="", subject_name=None, dns_name=None, principal_name=None,
             ):
                 self.test_obj = test_obj
                 self.ca = ca
@@ -328,6 +328,9 @@ class TestApplication(testlib.MachineCase):
                 self.nickname = nickname
                 self.cert_path = cert_path
                 self.key_path = key_path
+                self.subject_name = subject_name
+                self.dns_name = dns_name
+                self.principal_name = principal_name
 
             def execute(self):
                 self.open()
@@ -354,6 +357,16 @@ class TestApplication(testlib.MachineCase):
                     b.set_input_text("input[placeholder='Path to store the certificate']", self.cert_path)
                     b.set_input_text("input[placeholder='Path to store the generated key or to an existing key']", self.key_path)
 
+                if self.subject_name or self.dns_name or self.principal_name:
+                    b.click("#set-signing-parameters")
+
+                    if self.subject_name:
+                        b.set_input_text("#subject-name", self.subject_name)
+                    if self.dns_name:
+                        b.set_input_text("#dns-name", self.dns_name)
+                    if self.principal_name:
+                        b.set_input_text("#principal-name", self.principal_name)
+
             def cancel(self):
                 b.click(".modal-footer button:contains(Cancel)")
                 b.wait_not_present(".modal-dialog")
@@ -368,12 +381,20 @@ class TestApplication(testlib.MachineCase):
                     self.nickname = b.text("#certificate-0-name")
 
                 b.click("button#expandable-toggle0")
+
+                if self.subject_name:
+                    b.wait_in_text("#certificate-0-general-subject", self.subject_name)
+                if self.principal_name:
+                    b.wait_in_text("#certificate-0-general-principal", self.principal_name)
+                if self.dns_name:
+                    b.wait_in_text("#certificate-0-general-dns", self.dns_name)
+
                 if self.storage_type == "NSSDB":
-                        b.wait_in_text("#certificate-0-name", self.nickname)
-                        b.click("#certificate-0-cert-tab")
-                        b.wait_in_text("#certificate-0-cert-storage", "NSSDB")
-                        b.click("#certificate-0-keys-tab")
-                        b.wait_in_text("#certificate-0-key-storage", "NSSDB")
+                    b.wait_in_text("#certificate-0-name", self.nickname)
+                    b.click("#certificate-0-cert-tab")
+                    b.wait_in_text("#certificate-0-cert-storage", "NSSDB")
+                    b.click("#certificate-0-keys-tab")
+                    b.wait_in_text("#certificate-0-key-storage", "NSSDB")
                 else:
                     if self.key_path:
                         b.click("#certificate-0-keys-tab")
@@ -383,15 +404,26 @@ class TestApplication(testlib.MachineCase):
                         b.wait_in_text("#certificate-0-cert-location", self.cert_path)
 
             def verify_backend(self):
+                if self.subject_name:
+                    command_output = m.execute("getcert list -d /etc/pki/nssdb -n {0} | grep 'subject:' | awk '{{print $2}}'".format(self.nickname))
+                    self.test_obj.assertEqual(command_output, "CN={0}\n".format(self.subject_name))
+                if self.dns_name:
+                    command_output = m.execute("getcert list -d /etc/pki/nssdb -n {0} | grep 'dns:' | awk '{{print $2}}'".format(self.nickname))
+                    self.test_obj.assertEqual(command_output, "{0}\n".format(self.dns_name))
+                if self.principal_name:
+                    command_output = m.execute("getcert list -d /etc/pki/nssdb -n {0} | grep 'principal name:' | awk '{{print $3}}'".format(self.nickname))
+                    self.test_obj.assertEqual(command_output, "{0}\n".format(self.principal_name))
+
                 if self.storage_type == "NSSDB":
-                    command_output = m.execute("selfsign-getcert list -d /etc/pki/nssdb -n {0} | grep 'key pair storage:' | awk '{{print $4}}'".format(self.nickname))
-                    self.test_obj.assertEqual(command_output, "type=NSSDB,location='/etc/pki/nssdb',nickname='{0}',token='NSS\n".format(self.nickname))
-                    command_output = m.execute("selfsign-getcert list -d /etc/pki/nssdb -n {0} | grep 'certificate:' | awk '{{print $2}}'".format(self.nickname))
-                    self.test_obj.assertEqual(command_output, "type=NSSDB,location='/etc/pki/nssdb',nickname='{0}',token='NSS\n".format(self.nickname))
+                    command_output = m.execute("getcert list -d /etc/pki/nssdb -n {0} | grep 'key pair storage:' | awk '{{print $4}}'".format(self.nickname))
+                    print(command_output)
+                    self.test_obj.assertTrue("type=NSSDB,location='/etc/pki/nssdb',nickname='{0}'".format(self.nickname) in command_output)
+                    command_output = m.execute("getcert list -d /etc/pki/nssdb -n {0} | grep 'certificate:' | awk '{{print $2}}'".format(self.nickname))
+                    self.test_obj.assertTrue("type=NSSDB,location='/etc/pki/nssdb',nickname='{0}'".format(self.nickname) in command_output)
                 elif self.storage_type == "File":
-                    command_output = m.execute("selfsign-getcert list -f {0} | grep 'key pair storage:' | awk '{{print $4}}'".format(self.cert_path))
+                    command_output = m.execute("getcert list -f {0} | grep 'key pair storage:' | awk '{{print $4}}'".format(self.cert_path))
                     self.test_obj.assertEqual(command_output, "type=FILE,location='{0}'\n".format(self.key_path))
-                    command_output = m.execute("selfsign-getcert list -f {0} | grep 'certificate:' | awk '{{print $2}}'".format(self.cert_path))
+                    command_output = m.execute("getcert list -f {0} | grep 'certificate:' | awk '{{print $2}}'".format(self.cert_path))
                     self.test_obj.assertEqual(command_output, "type=FILE,location='{0}'\n".format(self.cert_path))
 
             def cleanup(self):
@@ -424,6 +456,15 @@ class TestApplication(testlib.MachineCase):
             storage_type="File",
         ).execute()
 
+        # Test subject name, dns name and principal name
+        RequestCertDialog(
+            self,
+            nickname="testcert3",
+            storage_type="NSSDB",
+            subject_name="TEST_HOSTNAME",
+            dns_name="example.com",
+            principal_name="HTTP/TEST_HOSTNAME",
+        ).execute()
 
 if __name__ == '__main__':
     testlib.test_main()

--- a/test/check-application
+++ b/test/check-application
@@ -573,5 +573,52 @@ class TestApplication(MachineCase):
             principal_name="HTTP/TEST_HOSTNAME",
         ).execute()
 
+    def testResubmit(self):
+        b = self.browser
+        m = self.machine
+
+        cert_name = "Server-Cert"
+        db_path = "/etc/pki/nssdb"
+        dns_name = "example.com"
+        m.execute("selfsign-getcert request -d {0} -n {1} -D {2}".format(db_path, cert_name, dns_name))
+
+        self.login_and_go("/certificates")
+        # Verify expected heading
+        b.wait_in_text(".ct-table-header h3", "Certificates")
+
+        b.wait_in_text("#certificate-0-name", cert_name)
+        b.click("button#expandable-toggle0")
+
+        old_validity = b.text("#certificate-0-general-validity")
+        time.sleep(1) # To prevent race-condition: wait 1 second so resubmitted certificate would have the same time validity in the UI as before
+
+        b.wait_not_present("#certificate-0-general-subject")
+        b.wait_not_present("#certificate-0-general-principal")
+        b.wait_in_text("#certificate-0-general-dns", dns_name)
+
+        # Resubmit certificate with different signing request parameters
+        b.click("#certificate-0-action-kebab button")
+        b.click("#certificate-0-resubmit a")
+        b.wait_in_text(".modal-title", "Resubmit Certificate")
+
+        # Change signing request propertes for resubmit
+        subject_name="CN=TEST_HOSTAME"
+        principal_name="HTTP/TEST_HOSTNAME",
+        b.set_input_text("#subject-name", subject_name)
+        b.set_input_text("#principal-name", principal_name)
+        b.set_input_text("#dns-name", "") # Remove DNS name
+
+        b.click(".modal-footer button:contains(Resubmit)")
+        b.wait_not_present(".modal-dialog")
+
+        # Check validity time differs which means certificate was resubmitted and renewed
+        new_validity = b.text("#certificate-0-general-validity")
+        self.assertNotEqual(old_validity, new_validity)
+
+        # Check signing properties are updated
+        b.wait_in_text("#certificate-0-general-subject", subject_name)
+        b.wait_in_text("#certificate-0-general-principal", principal_name)
+        b.wait_not_present("#certificate-0-general-dns")
+
 if __name__ == '__main__':
     test_main()

--- a/test/check-application
+++ b/test/check-application
@@ -12,9 +12,9 @@ import time
 TEST_DIR = os.path.dirname(__file__)
 sys.path.append(os.path.join(TEST_DIR, "common"))
 sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
-import testlib
+from testlib import *
 
-class TestApplication(testlib.MachineCase):
+class TestApplication(MachineCase):
     def setUp(self):
         super().setUp()
 
@@ -309,6 +309,113 @@ class TestApplication(testlib.MachineCase):
         # Check files were deleted
         m.execute("! test -f {0}; ! test -f {1}".format(cert_path, key_path))
 
+    def testImportCert(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/certificates")
+        # verify expected heading
+        b.wait_in_text(".ct-table-header h3", "Certificates")
+
+        class ImportCertDialog(object):
+            def __init__(
+                self, test_obj, ca="SelfSign", storage_type="File",
+                key_path="", cert_path="", subject_name=None, dns_name=None, principal_name=None,
+            ):
+                self.test_obj = test_obj
+                self.ca = ca
+                self.storage_type = storage_type
+                self.cert_path = cert_path
+                self.key_path = key_path
+                self.subject_name = subject_name
+                self.dns_name = dns_name
+                self.principal_name = principal_name
+
+            def execute(self):
+                self.open()
+                self.fill()
+                self.create()
+                self.verify_backend()
+                self.verify_frontend()
+                self.cleanup()
+
+            def open(self):
+                b.click("#import-certificate-action")
+                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Import Certificate")
+
+            def fill(self):
+                if self.ca:
+                    b.select_from_dropdown("#ca", self.ca)
+
+                b.set_input_text("input[placeholder='Path to an existing certificate file']", self.cert_path)
+                b.set_input_text("input[placeholder='Path to an existing key file']", self.key_path)
+
+            def cancel(self):
+                b.click(".modal-footer button:contains(Cancel)")
+                b.wait_not_present(".modal-dialog")
+
+            def create(self):
+                b.click(".modal-footer button:contains(Import)")
+                b.wait_not_present(".modal-dialog")
+
+            def verify_frontend(self):
+                b.click("button#expandable-toggle0")
+
+                b.wait_in_text("#certificate-0-general-subject", self.subject_name)
+                b.wait_in_text("#certificate-0-general-principal", self.principal_name)
+                b.wait_in_text("#certificate-0-general-dns", self.dns_name)
+
+                b.click("#certificate-0-keys-tab")
+                b.wait_in_text("#certificate-0-key-location", self.key_path)
+                b.click("#certificate-0-cert-tab")
+                b.wait_in_text("#certificate-0-cert-location", self.cert_path)
+
+            def verify_backend(self):
+                command_output = m.execute("getcert list -f {0} | grep 'subject:' | awk '{{print $2}}'".format(self.cert_path))
+                self.test_obj.assertEqual(command_output, "CN={0}\n".format(self.subject_name))
+                command_output = m.execute("getcert list -f {0} | grep 'dns:' | awk '{{print $2}}'".format(self.cert_path))
+                self.test_obj.assertEqual(command_output, "{0}\n".format(self.dns_name))
+                command_output = m.execute("getcert list -f {0} | grep 'principal name:' | awk '{{print $3}}'".format(self.cert_path))
+                self.test_obj.assertEqual(command_output, "{0}\n".format(self.principal_name))
+                command_output = m.execute("getcert list -f {0} | grep 'key pair storage:' | awk '{{print $4}}'".format(self.cert_path))
+                self.test_obj.assertEqual(command_output, "type=FILE,location='{0}'\n".format(self.key_path))
+                command_output = m.execute("getcert list -f {0} | grep 'certificate:' | awk '{{print $2}}'".format(self.cert_path))
+                self.test_obj.assertEqual(command_output, "type=FILE,location='{0}'\n".format(self.cert_path))
+
+            def cleanup(self):
+                m.execute("selfsign-getcert stop-tracking -f {0} -k {1}".format(self.cert_path, self.key_path))
+                b.reload()
+                b.enter_page('/certificates')
+
+
+        cert_path = "/etc/pki/tls/certs/myCert.cert"
+        key_path = "/etc/pki/tls/private/myKey.key"
+        subject_name = "TEST_HOSTNAME"
+        dns_name = "example.com"
+        principal_name = "TEST_HOSTNAME@REDHAT.COM"
+        # Request certificate which would result with a cert file with specified subject name, dns name and principal name
+        m.execute("selfsign-getcert request -f {0} -k {1} -N 'CN={2}' -D {3} -K {4}".format(cert_path, key_path, subject_name, dns_name, principal_name))
+        wait(lambda: "MONITORING" in m.execute("selfsign-getcert list -f {0}".format(cert_path)), delay=1)
+        # Stop tracking the cert. Files should be left untouched.
+        m.execute("selfsign-getcert stop-tracking -f {0}".format(cert_path, key_path))
+        b.reload()
+        b.enter_page('/certificates')
+
+        # Test importing the file
+        # Point of this test is to see if after importing a certificate from certificate file will
+        # result in a certificate with correct subject name, dns name and principal name without
+        # need to specify it in the UI. That means that importing went properly.
+        ImportCertDialog(
+            self,
+            ca="SelfSign",
+            cert_path=cert_path,
+            key_path=key_path,
+            storage_type="File",
+            subject_name=subject_name,
+            dns_name=dns_name,
+            principal_name=principal_name,
+        ).execute()
+
     def testRequestCert(self):
         b = self.browser
         m = self.machine
@@ -467,4 +574,4 @@ class TestApplication(testlib.MachineCase):
         ).execute()
 
 if __name__ == '__main__':
-    testlib.test_main()
+    test_main()


### PR DESCRIPTION
@andreasn mind giving it a design review?

![Screenshot from 2020-06-19 14-00-13](https://user-images.githubusercontent.com/42733240/85131485-31ff9400-b237-11ea-8656-7e4ad9534f4b.png)

When resubmiting certificate, user has ability to change CA to which certificate will be resubmitted and by which it will be renewed. User also has ability to change signing request properties, which is only way how to change them, because they need to be present when certificate is issued by CA.
Properties which cannot be changed during resubmition (like database path and nickname in this case), but are important to identify the certificate are shown in `<samp>` element.
![Screenshot from 2020-06-19 14-00-23](https://user-images.githubusercontent.com/42733240/85131494-35931b00-b237-11ea-9baf-8281e3166d02.png)
