### PR TITLE
Bump test/common dependency to 233

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ bots:
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 229
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 233
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 


### PR DESCRIPTION
This unblocks some Fedora image reorganization [1] which will in turn
make image preparations faster and more robust.

[1] https://github.com/cockpit-project/bots/pull/1407