### PR TITLE
Close dialog when certificate is removed

### DIFF
--- a/src/certificateActions.jsx
+++ b/src/certificateActions.jsx
@@ -51,32 +51,32 @@ export class RemoveModal extends React.Component {
         this.setState({ [key]: value });
     }
 
+    onRemoveResponse() {
+        const { certPath, certs, appOnValueChanged, onClose } = this.props;
+        delete certs[certPath];
+
+        appOnValueChanged("certs, certs");
+        onClose();
+    }
+
     onRemove() {
-        const { certPath, cert, addAlert, appOnValueChanged, onClose } = this.props;
+        const { certPath, cert, addAlert, onClose } = this.props;
         const { deleteFiles } = this.state;
 
         if (deleteFiles) {
             cockpit.file(cert["key-file"].v, { superuser: "try" }).replace(null) // delete key file
                     .then(() => cockpit.file(cert["cert-file"].v, { superuser: "try" }).replace(null)) // delete cert file
                     .then(() => removeRequest(certPath))
-                    .then(() => { // There is no dbus signal for cert removal, so we have to update UI manually
-                        const { certs } = this.props;
-                        delete certs[certPath];
-
-                        appOnValueChanged("certs, certs");
-                    })
+                    // There is no dbus signal for cert removal, so we have to update UI manually
+                    .then(() => this.onRemoveResponse())
                     .catch(error => {
                         addAlert(_("Error: ") + (error.name || error.problem), error.message);
                         onClose();
                     });
         } else {
             removeRequest(certPath)
-                    .then(() => { // There is no dbus signal for cert removal, so we have to update UI manually
-                        const { certs } = this.props;
-                        delete certs[certPath];
-
-                        appOnValueChanged("certs, certs");
-                    })
+                    // There is no dbus signal for cert removal, so we have to update UI manually
+                    .then(() => this.onRemoveResponse())
                     .catch(error => {
                         addAlert(_("Error: ") + error.name, error.message);
                         onClose();

--- a/test/check-application
+++ b/test/check-application
@@ -246,6 +246,9 @@ class TestApplication(testlib.MachineCase):
         db_path = "/etc/pki/nssdb"
         m.execute("selfsign-getcert request -d {0} -n {1}".format(db_path, cert_name))
 
+        cert_name2 = "Server-Cert2"
+        m.execute("selfsign-getcert request -d {0} -n {1}".format(db_path, cert_name2))
+
         self.login_and_go("/certificates")
         b.wait_in_text(".ct-table-header h3", "Certificates")
 
@@ -257,6 +260,15 @@ class TestApplication(testlib.MachineCase):
         b.click("#certificate-0-remove a")
         b.wait_in_text(".pf-c-modal-box__title", "Remove Certificate")
         b.wait_not_present("#certificate-0-delete-files") # Check delete files option is not present for NSSDB-stored certificate
+        b.click(".pf-c-modal-box__footer button:contains(Remove)")
+        b.wait_not_present(".pf-c-modal-box")
+
+        b.wait_in_text("#certificate-0-name", cert_name2)
+
+        # Remove second certificate
+        b.click("#certificate-0-action-kebab button")
+        b.click("#certificate-0-remove a")
+        b.wait_in_text(".pf-c-modal-box__title", "Remove Certificate")
         b.click(".pf-c-modal-box__footer button:contains(Remove)")
         b.wait_not_present(".pf-c-modal-box")
 


### PR DESCRIPTION
Before this change removing one certificate did not close the dialog
but showed a removal dialog for the next certificate until the `certs`
array was empty. Additionally this commit refactors common code into one
function.