### PR TITLE
Rebuild webpack during RPM build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,13 +84,11 @@ dist-gzip: $(TARFILE)
 # node_modules/ can be reconstructed if necessary)
 $(TARFILE): NODE_ENV=production
 $(TARFILE): $(WEBPACK_TEST) cockpit-$(PACKAGE_NAME).spec
-	mv node_modules node_modules.release
 	touch -r package.json $(NODE_MODULES_TEST)
 	touch dist/*
 	tar czf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
-		--exclude cockpit-$(PACKAGE_NAME).spec.in \
+		--exclude cockpit-$(PACKAGE_NAME).spec.in --exclude node_modules \
 		$$(git ls-files) $(LIB_TEST) src/lib/patternfly/*.scss package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
-	mv node_modules.release node_modules
 
 srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ update-po: po/$(PACKAGE_NAME).pot
 	sed -e 's/%{VERSION}/$(VERSION)/g' $< > $@
 
 $(WEBPACK_TEST): $(NODE_MODULES_TEST) $(LIB_TEST) $(shell find src/ -type f) package.json webpack.config.js
-	NODE_ENV=$(NODE_ENV) npm run build
+	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack
 
 watch:
-	NODE_ENV=$(NODE_ENV) npm run watch
+	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack --watch
 
 clean:
 	rm -rf dist/

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ TEST_OS = fedora-34
 endif
 export TEST_OS
 TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz
+NODE_CACHE=cockpit-$(PACKAGE_NAME)-node-$(VERSION).tar.xz
 RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q cockpit-$(PACKAGE_NAME).spec.in).rpm
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
@@ -90,6 +91,11 @@ $(TARFILE): $(WEBPACK_TEST) cockpit-$(PACKAGE_NAME).spec
 		--exclude cockpit-$(PACKAGE_NAME).spec.in --exclude node_modules \
 		$$(git ls-files) src/lib package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
 
+$(NODE_CACHE): $(NODE_MODULES_TEST)
+	tar --xz -cf $@ node_modules
+
+node-cache: $(NODE_CACHE)
+
 srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \
 	  --define "_sourcedir `pwd`" \
@@ -158,4 +164,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install dist-gzip srpm rpm check vm update-po
+.PHONY: all clean install devel-install dist-gzip node-cache srpm rpm check vm update-po

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ $(TARFILE): $(WEBPACK_TEST) cockpit-$(PACKAGE_NAME).spec
 	touch dist/*
 	tar czf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude cockpit-$(PACKAGE_NAME).spec.in --exclude node_modules \
-		$$(git ls-files) $(LIB_TEST) src/lib/patternfly/*.scss package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
+		$$(git ls-files) src/lib package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
 
 srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(NODE_CACHE): $(NODE_MODULES_TEST)
 
 node-cache: $(NODE_CACHE)
 
-srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
+srpm: $(TARFILE) $(NODE_CACHE) cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \
 	  --define "_sourcedir `pwd`" \
 	  --define "_srcrpmdir `pwd`" \
@@ -104,7 +104,7 @@ srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 
 rpm: $(RPMFILE)
 
-$(RPMFILE): $(TARFILE) cockpit-$(PACKAGE_NAME).spec
+$(RPMFILE): $(TARFILE) $(NODE_CACHE) cockpit-$(PACKAGE_NAME).spec
 	mkdir -p "`pwd`/output"
 	mkdir -p "`pwd`/rpmbuild"
 	rpmbuild -bb \

--- a/cockpit-certificates.spec.in
+++ b/cockpit-certificates.spec.in
@@ -6,7 +6,9 @@ License:        LGPLv2+ and MIT
 URL:            https://github.com/skobyda/cockpit-certificates
 
 Source0:        https://github.com/skobyda/cockpit-certificates/releases/download/%{version}/cockpit-certificates-%{version}.tar.gz
+Source1:        https://github.com/skobyda/cockpit-certificates/releases/download/%{version}/cockpit-certificates-node-%{version}.tar.xz
 BuildArch:      noarch
+BuildRequires:  nodejs
 BuildRequires:  libappstream-glib
 BuildRequires:  make
 
@@ -17,10 +19,13 @@ Requires: certmonger
 Cockpit component for managing certificates with certmonger.
 
 %prep
-%setup -n cockpit-certificates
+%setup -q -n cockpit-certificates
+%setup -q -a 1 -n cockpit-certificates
 
 %build
-# Nothing to build
+# ignore pre-built webpack in release tarball and rebuild it
+rm -rf dist
+NODE_ENV=production make
 
 %install
 %make_install

--- a/packit.yml
+++ b/packit.yml
@@ -4,7 +4,11 @@
 
 specfile_path: cockpit-certificates.spec
 actions:
-  post-upstream-clone: make cockpit-certificates.spec
+  post-upstream-clone:
+    - make cockpit-certificates.spec
+    # replace Source1 manually, as create-archive: can't handle multiple tarballs
+    - make node-cache
+    - sh -c 'sed -i "/^Source1:/ s/https:.*/$(ls cockpit-certificates-node*.tar.xz)/" cockpit-certificates.spec'
   # reduce memory consumption of webpack in sandcastle container
   # https://github.com/packit/sandcastle/pull/92
   # https://medium.com/the-node-js-collection/node-js-memory-management-in-container-environments-7eb8409a74e8


### PR DESCRIPTION
This is necessary to comply with Fedora's packaging policy:
https://docs.fedoraproject.org/en-US/packaging-guidelines/JavaScript/

Include the node cache in the source rpm, unpack it into the main source
dir, and force a webpack rebuild in `%build`.

----

Tested the integration with cockpituous with:
```
$ export RELEASE_SOURCE="_release/source"
$ ~/upstream/cockpituous/release/release-source
$ ~/upstream/cockpituous/release/release-github
> Creating release draft: 2
> Uploading file: _release/source/cockpit-certificates-2.tar.gz
####################################################################################################################### 100.0%
> Uploading file: _release/source/cockpit-certificates-node-2.tar.xz
####################################################################################################################### 100.0%
> Publishing draft: 2
```

This created a proper release (which I deleted again, sorry for the noise!)