### PR TITLE
Fix builds with npm 7, fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
 	TEST_AUDIT_NO_SELINUX=1 test/common/run-tests
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
-# must be from master, as only that has current and existing images; but testvm.py API is stable
+# must be from main, as only that has current and existing images; but testvm.py API is stable
 # support CI testing against a bots change
 bots:
 	git clone --quiet --reference-if-able $${XDG_CACHE_HOME:-$$HOME/.cache}/cockpit-project/bots https://github.com/cockpit-project/bots.git

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Run `make check` to build an RPM, install it into a standard Cockpit test VM
 it. This uses Cockpit's Chrome DevTools Protocol based browser tests, through a
 Python API abstraction. Note that this API is not guaranteed to be stable, so
 if you run into failures and don't want to adjust tests, consider checking out
-Cockpit's test/common from a tag instead of master (see the `test/common`
+Cockpit's test/common from a tag instead of main (see the `test/common`
 target in `Makefile`).
 
 After the test VM is prepared, you can manually run the test without rebuilding
@@ -94,13 +94,13 @@ To run the tests in the exact same way for upstream pull requests and for
 tests are wrapped in the [FMF metadata format](https://github.com/psss/fmf)
 for using with the [tmt test management tool](https://docs.fedoraproject.org/en-US/ci/tmt/).
 Note that Packit tests can *not* run their own virtual machine images, thus
-they only run [@nondestructive tests](https://github.com/cockpit-project/cockpit/blob/master/test/common/testlib.py).
+they only run [@nondestructive tests](https://github.com/cockpit-project/cockpit/blob/main/test/common/testlib.py).
 
 # Automated maintenance
 
 It is important to keep your [NPM modules](./package.json) up to date, to keep
 up with security updates and bug fixes. This is done with the
-[npm-update bot script](https://github.com/cockpit-project/bots/blob/master/npm-update)
+[npm-update bot script](https://github.com/cockpit-project/bots/blob/main/npm-update)
 which is run weekly or upon [manual request](https://github.com/skobyda/cockpit-certificates/actions) through the
 [npm-update.yml](.github/workflows/npm-update.yml) [GitHub action](https://github.com/features/actions).
 
@@ -113,4 +113,4 @@ To run the tests in the exact same way for upstream pull requests and for
 tests are wrapped in the [FMF metadata format](https://github.com/psss/fmf)
 for using with the [tmt test management tool](https://docs.fedoraproject.org/en-US/ci/tmt/).
 Note that Packit tests can *not* run their own virtual machine images, thus
-they only run [@nondestructive tests](https://github.com/martinpitt/cockpit/blob/master/test/common/testlib.py).
+they only run [@nondestructive tests](https://github.com/martinpitt/cockpit/blob/main/test/common/testlib.py).

--- a/cockpituous-release
+++ b/cockpituous-release
@@ -1,5 +1,5 @@
 # This is a script run to release welder-web through Cockpituous:
-# https://github.com/cockpit-project/cockpituous/tree/master/release
+# https://github.com/cockpit-project/cockpituous/tree/main/release
 
 # Anything that start with 'job' may run in a way that it SIGSTOP's
 # itself when preliminary preparition and then gets a SIGCONT in

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -12,15 +12,12 @@ LOGS="$(pwd)/logs"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 
-# install browser; on RHEL, use chromium from epel
-# HACK: chromium-headless ought to be enough, but version 88 has a crash: https://bugs.chromium.org/p/chromium/issues/detail?id=1170634
-if ! rpm -q chromium; then
-    if grep -q 'ID=.*rhel' /etc/os-release; then
-        dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-        dnf config-manager --enable epel
-    fi
-    dnf install -y chromium
-fi
+# install firefox (available everywhere in Fedora and RHEL); install the package to pull in all the dependencies
+# we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
+dnf install --disablerepo=fedora-cisco-openh264 -y firefox
+# install nightly for Chrome DevTools Protocol support
+curl --location 'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US' | tar -C /usr/local/lib/ -xj
+ln -s /usr/local/lib/firefox/firefox /usr/local/bin/
 
 # create user account for logging in
 if ! id admin 2>/dev/null; then
@@ -50,7 +47,7 @@ echo core > /proc/sys/kernel/core_pattern
 systemctl enable --now cockpit.socket
 
 # Run tests as unprivileged user
-su - -c "env SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
+su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
 
 RC=$(cat $LOGS/exitcode)
 exit ${RC:-1}

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -36,7 +36,7 @@ if ! id runtest 2>/dev/null; then
     useradd -c 'Test runner' runtest
     # allow test to set up things on the machine
     mkdir -p /root/.ssh
-    curl https://raw.githubusercontent.com/cockpit-project/bots/master/machine/identity.pub  >> /root/.ssh/authorized_keys
+    curl https://raw.githubusercontent.com/cockpit-project/bots/main/machine/identity.pub  >> /root/.ssh/authorized_keys
     chmod 600 /root/.ssh/authorized_keys
 fi
 chown -R runtest "$SOURCE"

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -5,7 +5,7 @@ require:
   - cockpit-ws
   - cockpit-system
   - bzip2
-  - git
+  - git-core
   - glibc-langpack-de
   - libvirt-python3
   - make

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -4,6 +4,7 @@ require:
   - cockpit-certificates
   - cockpit-ws
   - cockpit-system
+  - bzip2
   - git
   - glibc-langpack-de
   - libvirt-python3

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -4,11 +4,21 @@ set -eux
 # tests need cockpit's bots/ libraries and test infrastructure
 cd $SOURCE
 git init
+rm -f bots  # common local case: existing bots symlink
 make bots test/common
 
-# only install a subset to save time/space
-rm -f package-lock.json  # otherwise the command below installs *everything*, argh
-npm install chrome-remote-interface sizzle
+# support running from clean git tree
+if [ ! -d node_modules/chrome-remote-interface ]; then
+    # copy package.json temporarily otherwise npm might try to install the dependencies from it
+    rm -f package-lock.json  # otherwise the command below installs *everything*, argh
+    mv package.json .package.json
+    # only install a subset to save time/space
+    npm install chrome-remote-interface sizzle
+    mv .package.json package.json
+fi
+
+# disable detection of affected tests; testing takes too long as there is no parallelization
+mv .git dot-git
 
 . /etc/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"

--- a/test/check-application
+++ b/test/check-application
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # Run this with --help to see available options for tracing and debugging
-# See https://github.com/cockpit-project/cockpit/blob/master/test/common/testlib.py
+# See https://github.com/cockpit-project/cockpit/blob/main/test/common/testlib.py
 # "class Browser" and "class MachineCase" for the available API.
 
 import os

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,8 +10,6 @@ const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
 
 const webpack = require("webpack");
 
-const nodedir = path.resolve((process.env.SRCDIR || __dirname), "node_modules");
-
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';
 
@@ -43,11 +41,11 @@ module.exports = {
         ]
     },
     resolve: {
-        modules: [ nodedir, path.resolve(__dirname, 'src/lib') ],
-        alias: { 'font-awesome': path.resolve(nodedir, 'font-awesome-sass/assets/stylesheets') },
+        modules: [ "node_modules", path.resolve(__dirname, 'src/lib') ],
+        alias: { 'font-awesome': 'font-awesome-sass/assets/stylesheets' },
     },
     resolveLoader: {
-        modules: [ nodedir, path.resolve(__dirname, 'src/lib') ],
+        modules: [ "node_modules", path.resolve(__dirname, 'src/lib') ],
     },
     externals: { "cockpit": "cockpit" },
     devtool: "source-map",


### PR DESCRIPTION
[building is broken with npm 7](https://logs.cockpit-project.org/logs/pull-2527-20211016-033056-831e5022-fedora-34-skobyda-cockpit-certificates/log.html) -- sorry, I forgot about this when I moved our tasks container.

packit tests are also broken due to chromium crashes, see e.g. https://github.com/skobyda/cockpit-certificates/pull/69 .

I took the opportunity to bring this back in sync with starter-kit.